### PR TITLE
Use https where possible

### DIFF
--- a/root/about/faq.html
+++ b/root/about/faq.html
@@ -69,7 +69,7 @@ API requests need to be sent to api.metacpan.org.
 
 ## How can I try the API?
 
-[http://explorer.metacpan.org/](http://explorer.metacpan.org/) is an easy way
+[https://explorer.metacpan.org/](https://explorer.metacpan.org/) is an easy way
 to try sending queries to the back-end.
 
 ## Why can't I link my PAUSE account?

--- a/root/author.html
+++ b/root/author.html
@@ -135,7 +135,7 @@
          <a href="http://cpants.cpanauthors.org/author/<% author.pauseid %>">CPANTS</a>
     </li>
     <li>
-        <a href="http://explorer.metacpan.org/?url=/author/<% author.pauseid %>">MetaCPAN Explorer</a>
+        <a href="https://explorer.metacpan.org/?url=/author/<% author.pauseid %>">MetaCPAN Explorer</a>
     </li>
     <li>
         <a href="https://cpan.metacpan.org/authors/id/<% author.pauseid.substr(0,1) %>/<% author.pauseid.substr(0,2) %>/<% author.pauseid %>/">Browse CPAN directory</a>

--- a/root/browse.html
+++ b/root/browse.html
@@ -13,7 +13,7 @@
   <li class="nav-header">Tools</li>
   <li><a href="/release/<% author %>/<% release %>/"><i class="fa fa-fw fa-info-circle black"></i>Release Info</a></li>
   <li><a href="/author/<% author %>/"><i class="fa fa-user fa-fw black"></i>Author</a></li>
-  <li><a href="<% api_external %>/source/<% base %>"><i class="fa fa-file-text-o fa-fw black"></i>Raw browser</a></li>
+  <li><a href="<% api_external_secure %>/source/<% base %>"><i class="fa fa-file-text-o fa-fw black"></i>Raw browser</a></li>
   <li class="nav-header">Info</li>
   <li><% count = files.grep(->{this.directory == 'true'}).size; count %> folder<% count != 1 ? "s" : "" %></li>
   <li><% count = files.grep(->{this.directory == 'false'}).size; count %> file<% count != 1 ? "s" : "" %></li>

--- a/root/diff.html
+++ b/root/diff.html
@@ -31,9 +31,9 @@ file.path = parts.join("/"); END -%>
     </li>
     <li>
       <%- IF type == 'source' %>
-      <a href="<% api_external %>/diff/file/<% diff.source.digest %>/<% diff.target.digest %>?content-type=text/plain">
+      <a href="<% api_external_secure %>/diff/file/<% diff.source.digest %>/<% diff.target.digest %>?content-type=text/plain">
       <%- ELSE %>
-      <a href="<% api_external %>/diff/release/<% diff.source %>/<% diff.target %>?content-type=text/plain">
+      <a href="<% api_external_secure %>/diff/release/<% diff.source %>/<% diff.target %>?content-type=text/plain">
       <%- END %>
         Raw diff
       </a>

--- a/root/inc/release-tools.html
+++ b/root/inc/release-tools.html
@@ -6,7 +6,7 @@
     </a>
 </li>
 <li>
-    <a href="http://explorer.metacpan.org/?url=/<% module ? ['module', module.author, module.release, module.path].join("/") : ['release', release.author, release.name].join("/") %>">
+    <a href="https://explorer.metacpan.org/?url=/<% module ? ['module', module.author, module.release, module.path].join("/") : ['release', release.author, release.name].join("/") %>">
     <i class="fa fa-list-alt fa-fw black"></i>MetaCPAN Explorer
     </a>
 </li>

--- a/root/pod.html
+++ b/root/pod.html
@@ -22,11 +22,11 @@
   <% END %>
   <li>
     <a href="/source/<% module.author %>/<% module.release %>/<% module.path %>"><i class="fa fa-fw fa-file-code-o black"></i>Source</a>
-    (<a href="<% api_external %>/source/<% module.author %>/<% module.release %>/<% module.path %>">raw</a>)
+    (<a href="<% api_external_secure %>/source/<% module.author %>/<% module.release %>/<% module.path %>">raw</a>)
   </li>
   <li>
     <a href="/source/<% module.author %>/<% module.release %>/<% module.path.split("/").splice(0,-1).join("/") %>"><i class="fa fa-fw fa-folder-open black"></i>Browse</a>
-    (<a href="<% api_external %>/source/<% module.author %>/<% module.release %>/">raw</a>)
+    (<a href="<% api_external_secure %>/source/<% module.author %>/<% module.release %>/">raw</a>)
   </li>
   <% PROCESS inc/release-info.html %>
   <li class="nav-header">Activity</li>

--- a/root/release.html
+++ b/root/release.html
@@ -11,7 +11,7 @@
     <% INCLUDE mobile/toolbar-search-form.html %>
     </li>
     <li class="nav-header"><span class="relatize"><% release.date.dt_http %></span></li>
-    <li><a href="/source/<% release.author %>/<% release.name %>/"><i class="fa fa-fw fa-folder-open black"></i>Browse</a> (<a href="<% api_external %>/source/<% release.author %>/<% release.name %>/">raw</a>)</li>
+    <li><a href="/source/<% release.author %>/<% release.name %>/"><i class="fa fa-fw fa-folder-open black"></i>Browse</a> (<a href="<% api_external_secure %>/source/<% release.author %>/<% release.name %>/">raw</a>)</li>
     <% PROCESS inc/release-info.html %>
     <li class="nav-header">Activity</li>
     <li><% INCLUDE inc/activity.html query = 'distribution=' _ release.distribution %></li>

--- a/root/source.html
+++ b/root/source.html
@@ -3,7 +3,7 @@
 <div class="breadcrumbs">
     <a href="/source/<% base = [module.author, module.release].join("/"); base %>"><% [module.author, module.release].join(" / ") %></a>
     <% doc_view_url = [base,module.path].join("/") %>
-    <% raw_url = [api_external,'source',base,module.path].join("/") %>
+    <% raw_url = [api_external_secure,'source',base,module.path].join("/") %>
   <% FOREACH part IN module.path.split("/"); base = base _ "/" _ part -%>
     / <% UNLESS loop.last %><a href="/source/<% base %>"><% part %></a><% ELSE %><% part %><% END %>
     <% END %>

--- a/root/wrapper.html
+++ b/root/wrapper.html
@@ -205,7 +205,7 @@
                     <a href="https://github.com/CPAN-API/metacpan-web">Fork metacpan.org</a>
                 </div>
                 <div class="hidden-xs col-sm-1 col-md-1" style="text-align: center">
-                    <a href="http://Perl.org/">Perl.org</a>
+                    <a href="https://www.perl.org/">Perl.org</a>
                 </div>
             </div>
 

--- a/t/controller/shared/release-info.t
+++ b/t/controller/shared/release-info.t
@@ -199,7 +199,7 @@ test_psgi app, sub {
             );
 
             $tx->like(
-                '//a[starts-with(@href, "http://explorer.metacpan.org/?url")]/@href',
+                '//a[starts-with(@href, "https://explorer.metacpan.org/?url")]/@href',
                 $type eq 'module'
                 ? qr!\?url=/module/\w+/${release}-${version}/.+!
                 : qr!\?url=/release/\w+/${release}-${version}\z!,


### PR DESCRIPTION
I noticed some pages on metacpan use http instead of https where there are https links available.

This PR changes the links to api.metacpan.org, explorer.metacpan.org and perl.org to use https.