### PR TITLE
[WIP]don't list modules from other releases

### DIFF
--- a/root/release.html
+++ b/root/release.html
@@ -43,7 +43,15 @@ provides      = [];
 modules       = [];
 FOREACH file IN files;
   IF file.documentation && file.module;
-    modules.push(file);
+    found = 0;
+    FOREACH module IN file.module;
+      IF module.name != file.documentation;
+        found = found + 1;
+        IF found == 1;
+          modules.push(file);
+        END;
+      END;          
+    END;
     FOREACH module IN file.module;
       IF module.name != file.documentation && module.indexed && module.authorized;
         # There must be a better way...


### PR DESCRIPTION
This is a try at https://github.com/CPAN-API/cpan-api/issues/125. I solved the problem of showing the modules from other releases, but in the search page, it's still wrong and I am not sure where that comes from. Maybe that is still from the api?