### PR TITLE
Set 0 to non-PAUSE user

### DIFF
--- a/lib/MetaCPAN/Web/Model/API/Favorite.pm
+++ b/lib/MetaCPAN/Web/Model/API/Favorite.pm
@@ -137,6 +137,10 @@ sub find_plussers {
     # find total non pauseid users who have ++ed the dist.
     my $total_nonauthors = ( $total_plussers - $total_authors );
 
+    # number of pauseid users can be more than total plussers
+    # then set 0 to non pauseid users
+    $total_nonauthors = 0 if $total_nonauthors < 0;
+
     return (
         {
             plusser_authors => \@plusser_details,


### PR DESCRIPTION
A small fix for #1430 , I'm not sure if it's the right fix though. Since we get the number of non-PAUSE user from total_plussers - PAUSE_user = non-PAUSE . I'm not sure why number of users with PAUSE id who ++ed the module sometimes it's more than number of total plussers. I guess that because those PAUSE users don't register for a user id with MetaCPAN?   So, I just assume that if the number of PAUSE users more than total plusser then just assume that nobody is non-PAUSE user can set 0 number. Please just close this PR if I'm wrong.