### PR TITLE
add explicit data: URI scheme support for use in images

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -102,6 +102,7 @@ sub view : Private {
     $self->add_favorites_data( $data, $reqs->{favorites}, $data );
 
     my $hr = HTML::Restrict->new;
+    $hr->set_uri_schemes( [ undef, 'http', 'https', 'data' ] );
     $hr->set_rules(
         {
             a       => [qw( href target )],


### PR DESCRIPTION
This addresses the issue <https://github.com/CPAN-API/metacpan-web/issues/935>.

| Page | Before | After |
|--------|----------|--------|
| [Test::podimage](https://metacpan.org/pod/Test::podimage) | <img src="https://cloud.githubusercontent.com/assets/94489/6205340/31aba502-b530-11e4-9e5f-fbc88e4e3e38.png" width="300" />  | <img src="https://cloud.githubusercontent.com/assets/94489/6205343/4572ecd0-b530-11e4-843d-1dd854f1aaa4.png" width="300" /> |
| [IPerl example](https://metacpan.org/pod/release/ZMUGHAL/Devel-IPerl-0.002/example/20150209_IPerl_display_demo.pod) | <img src="https://cloud.githubusercontent.com/assets/94489/6205345/54cca8b0-b530-11e4-81b2-b5a89bbfaa91.png" width="300" />   | <img src="https://cloud.githubusercontent.com/assets/94489/6205346/5cb4bc8e-b530-11e4-87d6-0c15bec7a933.png" width="300" /> |