### PR TITLE
Fix links in new feed and on news page.

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Feed.pm
+++ b/lib/MetaCPAN/Web/Controller/Feed.pm
@@ -35,9 +35,11 @@ sub news : Chained('index') PathPart Args(0) {
 
         my %e;
         $e{name} = $str =~ s/\A(.+)$//m ? $1 : 'No title';
+        my $a_name = $e{name};
+        $a_name =~ s/\W+//g;
         $str =~ s/\A\s*-+//g;
         $e{date}   = $str =~ s/^Date:\s*(.*)$//m ? $1 : '2014-01-01T00:00:00';
-        $e{link}   = "http://metacpan.org/news#$e{name}";
+        $e{link}   = "http://metacpan.org/news#$a_name";
         $e{author} = 'METACPAN';
         $str =~ s/^\s*|\s*$//g;
 

--- a/lib/MetaCPAN/Web/Controller/News.pm
+++ b/lib/MetaCPAN/Web/Controller/News.pm
@@ -12,9 +12,18 @@ sub news : Local : Path('/news') {
 
     my $file = $c->config->{home} . '/News.md';
     my $news = path($file)->slurp_utf8;
-    $news =~ s/^Title:\s*//gm;
+    $news =~ s|^Title:\s*(.*)|expand_title($1)|egm;
 
     $c->stash( template => 'news.html', news => $news );
+}
+
+sub expand_title {
+    my ($title) = @_;
+
+    my $a_name = $title;
+    $a_name =~ s/\W+//g;
+
+    return qq[<a name="$a_name" />$title];
 }
 
 1;


### PR DESCRIPTION
There were a couple of problems with the links in the News RSS feeds.

1. As they just use the title as the fragment, they were generating invalid URLs (ones that contained spaces).
2. The URLs in the feed didn't actually go anywhere useful - as the news page didn't include the &lt;a name="..."&gt; tags required to match the links in the feed.

This patch fixed both of those problems. It removes spaces from the URLs in the feed and adds matching &lt;a name="..."&gt; tags on the news page.

**However** the only way I could find to add the &lt;a name="..."&gt; into the news markdown was to insert raw HTML into the markdown just before it gets processed by the template engine. But you have HTML autoescaping turned on, which means my HTML is converted to &amp;lt;a name="..."&amp;gt; - which doesn't work.

So if you want your news page links to work then you'll need to a) apply this patch (or something similar) and b) turn off the HTML autoescaping.

If you can think of another solution, I'd love to hear it.