### PR TITLE
do not display .pod versions of documentation

### DIFF
--- a/lib/MetaCPAN/Web/Model/API/Release.pm
+++ b/lib/MetaCPAN/Web/Model/API/Release.pm
@@ -311,13 +311,13 @@ sub interesting_files {
                                                         }
                                                         } qw(
                                                         MANIFEST
-                                                        README README.md README.pod
-                                                        INSTALL INSTALL.md INSTALL.pod
+                                                        README README.md
+                                                        INSTALL INSTALL.md
                                                         FAQ
                                                         Makefile.PL Build.PL
                                                         LICENSE Copying COPYRIGHT
                                                         TODO ToDo Todo
-                                                        CONTRIBUTING CONTRIBUTING.md CONTRIBUTING.pod
+                                                        CONTRIBUTING CONTRIBUTING.md
                                                         CREDITS AUTHORS THANKS
                                                         CHANGES Changes ChangeLog Changelog CHANGELOG NEWS
                                                         META.yml META.json


### PR DESCRIPTION
.pod files in the root level of a Foo-Bar-Baz distribution are installed into
lib/Foo/Bar/*.pod, which pollutes the installation, so we should not encourage
this practice.