### PR TITLE
rename top menu entry "Feedback" to "Github Issues" to increase visibility

### DIFF
--- a/root/wrapper.html
+++ b/root/wrapper.html
@@ -12,7 +12,7 @@
     class = 'hidden-xs',
     },
     {
-    title = "Feedback",
+    title = "Github Issues",
     path = ["https://github.com/CPAN-API/metacpan-web/issues"],
     class = 'hidden-xs',
     },


### PR DESCRIPTION
The current item name "Feedback" is very vague, and doesn't make it clear
that behind it the source as well as the bug tracker can be found. By
making it mention Github it draws the eye because of how known it is, and
by making it mention issues (the general language used for bugs on
metacpan) it makes it clear that behind that link the bug tracker can be
found. This might make it easier for people to realize the possibility of
easy contribution and to do so.