### PR TITLE
add icons to the top menu to increase discoverability

### DIFF
--- a/root/wrapper.html
+++ b/root/wrapper.html
@@ -1,30 +1,36 @@
 <%- menu = [{
     title = "Home",
-    path = ["/", "/search"]
+    path = ["/", "/search"],
+    image = "/static/icons/favicon.ico",
     },
     {
     title = "Recent",
-    path = ["/recent"]
+    path = ["/recent"],
+    icon = "history",
     },
     {
     title = "FAQ",
     path = ["/about/faq"],
     class = 'hidden-xs',
+    icon = "question",
     },
     {
     title = "Feedback",
     path = ["https://github.com/CPAN-API/metacpan-web/issues"],
     class = 'hidden-xs',
+    icon = "github-alt",
     },
     {
     title = "News",
     path = ["/news"],
     class = 'hidden-xs',
+    icon = "rss",
     },
     {
     title = "Lab",
     path = ["/lab"],
     class = 'hidden-xs',
+    icon = "rocket",
     },
     ] %>
 <!DOCTYPE HTML>
@@ -99,7 +105,13 @@
                         <%- ELSE %>
                     <li class="<% item.class %>">
                         <%- END %>
-                        <a href="<% item.path.0 %>"><% item.title %></a>
+                        <a
+                          <%- IF item.icon %>class="fa fa-<% item.icon %>"<% END -%>
+                          href="<% item.path.0 %>">
+                            <%- IF item.image %><img src="<% item.image %>" /><% END -%>
+                            <%- IF item.icon || item.image %>&nbsp;<% END -%>
+                            <%- item.title -%>
+                        </a>
                     </li>
                     <%- END %>
                 </ul>


### PR DESCRIPTION
Adding icons to the top menu helps separate the entries from one another and provides a glanceable hint as to what each item is for that can be recognized by many people before actually reading the text.

This is only a crude and untested implementation. I prototyped in the browser and adapted the template to generate what i hope is an equivalent result.

Here's a preview in small and big:

![icon_preview](https://cloud.githubusercontent.com/assets/175467/6529985/59a546d8-c42d-11e4-96e3-b4ca3bf360e0.png)
