### PR TITLE
make vertical alignment of image-based icons in nav bar nicer-looking

### DIFF
--- a/root/static/less/nav.less
+++ b/root/static/less/nav.less
@@ -51,6 +51,9 @@
                 margin-bottom: -2px;
                 color: @linkColor;
             }
+            > img {
+                vertical-align: text-bottom;
+            }
         }
         .active {
             > a, > a:hover {


### PR DESCRIPTION
I have no idea if the code makes sense. If it works right, it should nudge the icons up a little to make the lower border align with the lowest border of the text it's next to.