### PR TITLE
Leo/fastly surrogate keys

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,12 @@ will generally be the right thing to do.  Our standards are improving, so even
 if you do follow what you see, we may ask you to make some changes, but that is
 a good thing.  We are trying to keep things tidy.
 
+If you are using the [developer VM](https://github.com/CPAN-API/metacpan-developer) you can run:
+
+```sh
+/home/vagrant/carton/metacpan-web/bin/tidyall
+```
+
 ## Perl Best Practices
 
 In general, the concepts discussed in "Perl Best Practices" are a good starting

--- a/app.psgi
+++ b/app.psgi
@@ -177,11 +177,17 @@ else {
 
         # Tell fastly to cache _asset and _asset_less for a day
         enable_if { $_[0]->{PATH_INFO} =~ m{^/_asset} } 'Headers',
-            set => [ 'Surrogate-Control' => "max-age=${day_ttl}" ];
+            set => [
+            'Surrogate-Control' => "max-age=${day_ttl}",
+            'Surrogate-Key'     => 'assets',
+            ];
 
         # Tell fastly to cache /static/ for an hour
         enable_if { $_[0]->{PATH_INFO} =~ m{^/static} } 'Headers',
-            set => [ 'Surrogate-Control' => "max-age=${hour_ttl}" ];
+            set => [
+            'Surrogate-Control' => "max-age=${hour_ttl}",
+            'Surrogate-Key'     => 'static',
+            ];
 
         $app;
     };

--- a/cpanfile
+++ b/cpanfile
@@ -54,6 +54,7 @@ requires 'MooseX::Types::Common::Numeric';
 requires 'MooseX::Types::Common::String';
 requires 'MooseX::Types::Moose';
 requires 'MooseX::Types::URI';
+requires 'Net::Fastly', '1.02';
 requires 'Path::Tiny', '0.056';
 requires 'Plack::Middleware::Assets';
 requires 'Plack::Middleware::ReverseProxy';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -2864,6 +2864,23 @@ DISTRIBUTIONS
       File::Temp 0
       Scalar::Util 0
       Test::More 0.88
+  IO-Socket-SSL-2.013
+    pathname: S/SU/SULLR/IO-Socket-SSL-2.013.tar.gz
+    provides:
+      IO::Socket::SSL 2.013
+      IO::Socket::SSL::Intercept 1.93
+      IO::Socket::SSL::OCSP_Cache 2.013
+      IO::Socket::SSL::OCSP_Resolver 2.013
+      IO::Socket::SSL::PublicSuffix undef
+      IO::Socket::SSL::SSL_Context 2.013
+      IO::Socket::SSL::SSL_HANDLE 2.013
+      IO::Socket::SSL::Session_Cache 2.013
+      IO::Socket::SSL::Utils 0.031
+    requirements:
+      ExtUtils::MakeMaker 0
+      Mozilla::CA 0
+      Net::SSLeay 1.46
+      Scalar::Util 0
   IO-String-1.08
     pathname: G/GA/GAAS/IO-String-1.08.tar.gz
     provides:
@@ -2967,6 +2984,18 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.006002
+  LWP-Protocol-https-6.06
+    pathname: M/MS/MSCHILLI/LWP-Protocol-https-6.06.tar.gz
+    provides:
+      LWP::Protocol::https 6.06
+      LWP::Protocol::https::Socket 6.06
+    requirements:
+      ExtUtils::MakeMaker 0
+      IO::Socket::SSL 1.54
+      LWP::UserAgent 6.06
+      Mozilla::CA 20110101
+      Net::HTTPS 6
+      perl 5.008001
   Lexical-SealRequireHints-0.007
     pathname: Z/ZE/ZEFRAM/Lexical-SealRequireHints-0.007.tar.gz
     provides:
@@ -3972,6 +4001,14 @@ DISTRIBUTIONS
       Scalar::Util 1.14
       XSLoader 0.02
       perl 5.008005
+  Mozilla-CA-20141217
+    pathname: A/AB/ABH/Mozilla-CA-20141217.tar.gz
+    provides:
+      Mozilla::CA 20141217
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test 0
+      perl 5.006
   Net-CIDR-Lite-0.21
     pathname: D/DO/DOUGW/Net-CIDR-Lite-0.21.tar.gz
     provides:
@@ -4064,11 +4101,48 @@ DISTRIBUTIONS
       IO::Socket 1.24
       MIME::Base64 2.11
       Test::More 0.52
-  Net-HTTP-6.06
-    pathname: G/GA/GAAS/Net-HTTP-6.06.tar.gz
+  Net-Fastly-1.02
+    pathname: F/FA/FASTLY/Net-Fastly-1.02.tar.gz
     provides:
-      Net::HTTP 6.06
-      Net::HTTP::Methods 6.06
+      Net::Fastly 1.02
+      Net::Fastly::Backend undef
+      Net::Fastly::BelongsToServiceAndVersion undef
+      Net::Fastly::Client undef
+      Net::Fastly::Condition undef
+      Net::Fastly::Customer undef
+      Net::Fastly::Director undef
+      Net::Fastly::Domain undef
+      Net::Fastly::Healthcheck undef
+      Net::Fastly::Invoice undef
+      Net::Fastly::Match undef
+      Net::Fastly::Model undef
+      Net::Fastly::Origin undef
+      Net::Fastly::Service undef
+      Net::Fastly::Settings undef
+      Net::Fastly::Stats undef
+      Net::Fastly::Syslog undef
+      Net::Fastly::User undef
+      Net::Fastly::VCL undef
+      Net::Fastly::Version undef
+    requirements:
+      Class::Accessor::Fast 0
+      File::Basename 0
+      File::Spec 0
+      File::Temp 0
+      IO::Socket::SSL != 1.38
+      JSON::XS 0
+      LWP::Protocol::https 0
+      LWP::UserAgent 5.813
+      Module::Build 0.38
+      Test::More 0
+      URI 0
+      URI::Escape 0
+      YAML 0
+  Net-HTTP-6.07
+    pathname: M/MS/MSCHILLI/Net-HTTP-6.07.tar.gz
+    provides:
+      Net::HTTP 6.07
+      Net::HTTP::Methods 6.07
       Net::HTTP::NB 6.04
       Net::HTTPS 6.04
     requirements:
@@ -4077,7 +4151,18 @@ DISTRIBUTIONS
       IO::Compress::Gzip 0
       IO::Select 0
       IO::Socket::INET 0
+      URI 0
       perl 5.006002
+  Net-SSLeay-1.68
+    pathname: M/MI/MIKEM/Net-SSLeay-1.68.tar.gz
+    provides:
+      Net::SSLeay 1.68
+      Net::SSLeay::Handle 0.61
+    requirements:
+      ExtUtils::MakeMaker 6.36
+      MIME::Base64 0
+      Test::More 0.60_01
+      perl 5.005
   Net-Server-2.007
     pathname: R/RH/RHANDOM/Net-Server-2.007.tar.gz
     provides:
@@ -6683,18 +6768,18 @@ DISTRIBUTIONS
       Test::More 0
       XSLoader 0
       perl 5.008001
-  libwww-perl-6.05
-    pathname: G/GA/GAAS/libwww-perl-6.05.tar.gz
+  libwww-perl-6.13
+    pathname: E/ET/ETHER/libwww-perl-6.13.tar.gz
     provides:
-      LWP 6.05
+      LWP 6.13
       LWP::Authen::Basic undef
       LWP::Authen::Digest undef
-      LWP::Authen::Ntlm 6.00
-      LWP::ConnCache 6.02
+      LWP::Authen::Ntlm 6.13
+      LWP::ConnCache 6.13
       LWP::Debug undef
       LWP::DebugFile undef
       LWP::MemberMixin undef
-      LWP::Protocol 6.00
+      LWP::Protocol 6.13
       LWP::Protocol::GHTTP undef
       LWP::Protocol::MyFTP undef
       LWP::Protocol::cpan undef
@@ -6709,9 +6794,9 @@ DISTRIBUTIONS
       LWP::Protocol::mailto undef
       LWP::Protocol::nntp undef
       LWP::Protocol::nogo undef
-      LWP::RobotUA 6.03
-      LWP::Simple 6.00
-      LWP::UserAgent 6.05
+      LWP::RobotUA 6.13
+      LWP::Simple 6.13
+      LWP::UserAgent 6.13
     requirements:
       Digest::MD5 0
       Encode 2.12
@@ -6733,7 +6818,7 @@ DISTRIBUTIONS
       LWP::MediaTypes 6
       MIME::Base64 2.1
       Net::FTP 2.58
-      Net::HTTP 6.04
+      Net::HTTP 6.07
       URI 1.10
       URI::Escape 0
       WWW::RobotRules 6

--- a/lib/MetaCPAN/Web.pm
+++ b/lib/MetaCPAN/Web.pm
@@ -9,6 +9,7 @@ use Catalyst qw/
     ConfigLoader
     Static::Simple
     Authentication
+    +MetaCPAN::Web::Role::Fastly
     /;
 
 extends 'Catalyst';

--- a/lib/MetaCPAN/Web/Controller/Account/Favorite.pm
+++ b/lib/MetaCPAN/Web/Controller/Account/Favorite.pm
@@ -3,6 +3,16 @@ package MetaCPAN::Web::Controller::Account::Favorite;
 use Moose;
 BEGIN { extends 'MetaCPAN::Web::Controller' }
 
+sub auto : Private {
+    my ( $self, $c ) = @_;
+
+    # Needed to clear the cache
+    my $user = $c->model('API::User')->get_profile( $c->token )->recv;
+    $c->stash->{user} = $user;
+
+    return 1;
+}
+
 sub add : Local {
     my ( $self, $c ) = @_;
     $c->detach('/forbidden') unless ( $c->req->method eq 'POST' );
@@ -15,6 +25,10 @@ sub add : Local {
     else {
         $res = $model->add_favorite( $data, $c->token )->recv;
     }
+
+    # Clear Fastly.. something changed
+    $c->purge_surrogate_key( $self->_cache_key_for_user($c) );
+
     if ( $c->req->looks_like_browser ) {
         $c->res->redirect(
               $res->{error}
@@ -31,10 +45,37 @@ sub add : Local {
 
 sub list : Local {
     my ( $self, $c ) = @_;
+    $self->_add_fav_list_to_stash( $c, 1_000 );
+}
 
-    my $user = $c->model('API::User')->get_profile( $c->token )->recv;
+sub list_as_json : Local {
+    my ( $self, $c ) = @_;
 
-    my $faves_cv   = $c->model('API::Favorite')->by_user( $user->{user} );
+    $self->_add_fav_list_to_stash( $c, 1_000 );
+
+    my $user = $c->stash->{user};
+
+    $c->add_surrogate_key( $self->_cache_key_for_user($c) );
+    $c->cdn_cache_ttl( 86_400 * 30 );    # 30 days
+
+    $c->detach( $c->view('JSON') );
+}
+
+sub _cache_key_for_user {
+    my ( $self, $c ) = @_;
+
+    my $user = $c->stash->{user};
+
+    return 'user/' . $user->{user};
+}
+
+sub _add_fav_list_to_stash {
+    my ( $self, $c, $size ) = @_;
+
+    my $user = $c->stash->{user};
+
+    my $faves_cv
+        = $c->model('API::Favorite')->by_user( $user->{user}, $size );
     my $faves_data = $faves_cv->recv;
     my $faves      = [
         sort { $b->{date} cmp $a->{date} }
@@ -42,6 +83,8 @@ sub list : Local {
     ];
 
     $c->stash( { faves => $faves } );
+
+    return $user;
 
 }
 

--- a/lib/MetaCPAN/Web/Controller/Root.pm
+++ b/lib/MetaCPAN/Web/Controller/Root.pm
@@ -105,17 +105,8 @@ sub end : ActionClass('RenderView') {
 
     $c->res->header( Vary => 'Cookie' );
 
-    unless (
-        # Already have something set for fastly
-        $c->res->header('Surrogate-Control') ||
+    $c->fastly_magic();
 
-        # We'll use Last-Modified for now
-        $c->res->header('Last-Modified')
-        )
-    {
-        # Make sure fastly doesn't cache anything by accident
-        $c->res->header( 'Surrogate-Control' => 'no-cache' );
-    }
 }
 
 =head1 AUTHOR

--- a/lib/MetaCPAN/Web/Model/API/Favorite.pm
+++ b/lib/MetaCPAN/Web/Model/API/Favorite.pm
@@ -76,7 +76,8 @@ sub get {
 }
 
 sub by_user {
-    my ( $self, $user ) = @_;
+    my ( $self, $user, $size ) = @_;
+    $size ||= 250;
     return $self->request(
         '/favorite/_search',
         {
@@ -84,7 +85,7 @@ sub by_user {
             filter => { term      => { user => $user }, },
             sort   => ['distribution'],
             fields => [qw(date author distribution)],
-            size   => 250,
+            size   => $size,
         }
     );
 }

--- a/lib/MetaCPAN/Web/Role/Fastly.pm
+++ b/lib/MetaCPAN/Web/Role/Fastly.pm
@@ -3,6 +3,8 @@ package MetaCPAN::Web::Role::Fastly;
 use Moose::Role;
 use Net::Fastly;
 
+use MetaCPAN::Web::Types qw( ArrayRef Str );
+
 =head1 NAME
 
 MetaCPAN::Web::Role::Fastly - Methods for fastly intergration
@@ -14,7 +16,7 @@ MetaCPAN::Web::Role::Fastly - Methods for fastly intergration
 has '_surrogate_keys' => (
     traits  => ['Array'],
     is      => 'ro',
-    isa     => 'ArrayRef[Str]',
+    isa     => ArrayRef [Str],
     default => sub { [] },
     handles => {
         add_surrogate_key   => 'push',
@@ -27,7 +29,7 @@ has '_surrogate_keys' => (
 has '_surrogate_keys_to_purge' => (
     traits  => ['Array'],
     is      => 'ro',
-    isa     => 'ArrayRef[Str]',
+    isa     => ArrayRef [Str],
     default => sub { [] },
     handles => {
         purge_surrogate_key          => 'push',

--- a/lib/MetaCPAN/Web/Role/Fastly.pm
+++ b/lib/MetaCPAN/Web/Role/Fastly.pm
@@ -1,0 +1,115 @@
+package MetaCPAN::Web::Role::Fastly;
+
+use Moose::Role;
+use Net::Fastly;
+
+=head1 NAME
+
+MetaCPAN::Web::Role::Fastly - Methods for fastly intergration
+
+=cut
+
+## Stuff for working with Fastly CDN
+
+has '_surrogate_keys' => (
+    traits  => ['Array'],
+    is      => 'ro',
+    isa     => 'ArrayRef[Str]',
+    default => sub { [] },
+    handles => {
+        add_surrogate_key   => 'push',
+        has_surrogate_keys  => 'count',
+        surrogate_keys      => 'elements',
+        join_surrogate_keys => 'join',
+    },
+);
+
+has '_surrogate_keys_to_purge' => (
+    traits  => ['Array'],
+    is      => 'ro',
+    isa     => 'ArrayRef[Str]',
+    default => sub { [] },
+    handles => {
+        purge_surrogate_key          => 'push',
+        has_surrogate_keys_to_purge  => 'count',
+        surrogate_keys_to_purge      => 'elements',
+        join_surrogate_keys_to_purge => 'join',
+    },
+);
+
+sub _net_fastly {
+    my $c = shift;
+
+    my $api_key = $c->config->{fastly_api_key};
+    my $fsi     = $c->config->{fastly_service_id};
+
+    return unless $api_key && $fsi;
+
+    # We have the credentials, so must be on production
+    my $fastly = Net::Fastly->new( api_key => $api_key );
+    return $fastly;
+}
+
+sub fastly_magic {
+    my $c = shift;
+
+    # Surrogate key caching and purging
+    if ( $c->has_surrogate_keys ) {
+
+        # See http://www.fastly.com/blog/surrogate-keys-part-1/
+        $c->res->header( 'Surrogate-Key' => $c->join_surrogate_keys(' ') );
+    }
+
+    if ( $c->has_surrogate_keys_to_purge ) {
+
+        # Something changed, means we need to purge some keys
+
+        my $net_fastly = $c->_net_fastly();
+        return unless $net_fastly;
+
+        my $fsi = $c->config->{fastly_service_id};
+
+        foreach my $purge_key ( $c->surrogate_keys_to_purge() ) {
+            my $purge_string
+                = "https://metacpan.org/${fsi}/purge/${purge_key}";
+
+            $net_fastly->purge($purge_string);
+        }
+    }
+
+    # Set the caching at CDN, seperate to what the user's browser does
+    # https://docs.fastly.com/guides/tutorials/cache-control-tutorial
+    if($c->cdn_never_cache) {
+
+      # Make sure fastly doesn't cache this by accident
+      $c->res->header( 'Surrogate-Control' => 'no-cache' );
+
+    } elsif( my $ttl = $c->cdn_cache_ttl ) {
+
+      # Use this value
+      $c->res->header( 'Surrogate-Control' => 'max_age=' . $ttl );
+
+    } elsif( !$c->res->header('Last-Modified') ) {
+
+      # If Last-Modified, Fastly can use that, otherwise default to no-cache
+      $c->res->header( 'Surrogate-Control' => 'no-cache' );
+
+    }
+}
+
+# How long should the CDN cache, irrespective of
+# other cache headers
+has 'cdn_cache_ttl' => (
+    is      => 'rw',
+    isa     => 'Int',
+    default => sub {0},
+);
+
+# Make sure the CDN NEVER caches, ignore any other cdn_cache_ttl settings
+has 'cdn_never_cache' => (
+    is      => 'rw',
+    isa     => 'Bool',
+    default => sub {0},
+);
+
+1;

--- a/lib/MetaCPAN/Web/Role/Fastly.pm
+++ b/lib/MetaCPAN/Web/Role/Fastly.pm
@@ -79,20 +79,22 @@ sub fastly_magic {
 
     # Set the caching at CDN, seperate to what the user's browser does
     # https://docs.fastly.com/guides/tutorials/cache-control-tutorial
-    if($c->cdn_never_cache) {
+    if ( $c->cdn_never_cache ) {
 
-      # Make sure fastly doesn't cache this by accident
-      $c->res->header( 'Surrogate-Control' => 'no-cache' );
+        # Make sure fastly doesn't cache this by accident
+        $c->res->header( 'Surrogate-Control' => 'no-cache' );
 
-    } elsif( my $ttl = $c->cdn_cache_ttl ) {
+    }
+    elsif ( my $ttl = $c->cdn_cache_ttl ) {
 
-      # Use this value
-      $c->res->header( 'Surrogate-Control' => 'max_age=' . $ttl );
+        # Use this value
+        $c->res->header( 'Surrogate-Control' => 'max_age=' . $ttl );
 
-    } elsif( !$c->res->header('Last-Modified') ) {
+    }
+    elsif ( !$c->res->header('Last-Modified') ) {
 
-      # If Last-Modified, Fastly can use that, otherwise default to no-cache
-      $c->res->header( 'Surrogate-Control' => 'no-cache' );
+        # If Last-Modified, Fastly can use that, otherwise default to no-cache
+        $c->res->header( 'Surrogate-Control' => 'no-cache' );
 
     }
 }


### PR DESCRIPTION
Add '/account/favourite/list_as_json' so we can switch to client side customisation for most pages.

This is also a start for smarter Fastly CDN integration.

Not from Oalders if we have SSL version issues https://github.com/gisle/mozilla-ca/pull/5