### PR TITLE
Leo/switch css js to cdn friendly

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -71,6 +71,7 @@ requires 'Plack::Test';
 requires 'Regexp::Common';
 requires 'Regexp::Common::time';
 requires 'Starman', '>= 0.4008';
+requires 'String::BOM', '0.3';
 requires 'Template::Alloy';
 requires 'Template::Plugin::DateTime';
 requires 'Template::Plugin::JSON';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -2470,6 +2470,17 @@ DISTRIBUTIONS
       strict 0
       utf8 0
       warnings 0
+  File-Slurp-9999.19
+    pathname: U/UR/URI/File-Slurp-9999.19.tar.gz
+    provides:
+      File::Slurp 9999.19
+      FileSlurp_12 9999.13
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Fcntl 0
+      POSIX 0
   File-Which-1.09
     pathname: A/AD/ADAMK/File-Which-1.09.tar.gz
     provides:
@@ -5399,6 +5410,14 @@ DISTRIBUTIONS
       Stream::Buffered::PerlIO undef
     requirements:
       ExtUtils::MakeMaker 6.36
+  String-BOM-0.3
+    pathname: D/DM/DMUEY/String-BOM-0.3.tar.gz
+    provides:
+      String::BOM 0.3
+    requirements:
+      File::Slurp 0
+      Test::More 0
+      version 0
   String-Format-1.17
     pathname: D/DA/DARREN/String-Format-1.17.tar.gz
     provides:

--- a/lib/MetaCPAN/Web/Controller/Assets.pm
+++ b/lib/MetaCPAN/Web/Controller/Assets.pm
@@ -1,0 +1,137 @@
+package MetaCPAN::Web::Controller::Assets;
+use Moose;
+use namespace::autoclean;
+
+use Capture::Tiny ':all';
+use CSS::Minifier::XS qw();
+use JavaScript::Minifier::XS qw();
+use String::BOM qw(string_has_bom strip_bom_from_string);
+
+BEGIN { extends 'MetaCPAN::Web::Controller' }
+
+=head1 NAME
+
+MetaCPAN::Web::Controller::Assets - css / js assets
+
+=head1 DESCRIPTION
+
+Generate assets dynamically, rely on CDN to cache them
+for the public and on DEV don't
+
+=cut
+
+=head2 style.css
+
+Pass static/less/style.less through less
+
+=cut
+
+sub css : Path('style.css') : Args(0) {
+    my ( $self, $c ) = @_;
+
+    $c->res->content_type('text/css');
+
+    my $file = 'root/static/less/style.less';
+
+    my $less = `lessc -v`;
+    croak(q{Can't find lessc command}) unless $less;
+
+    my ( $stdout, $stderr, $exit ) = capture {
+        system( 'lessc', $file );
+    };
+    die $stderr if $stderr;
+
+    # cdn cache
+    $c->add_surrogate_key('assets');
+    $c->add_surrogate_key('css');
+    $c->cdn_cache_ttl( $c->one_month );    # 30 days
+
+    if ( $ENV{PLACK_ENV} && $ENV{PLACK_ENV} eq 'development' ) {
+
+        # Make sure the user re-requests each time
+        $c->res->header( 'Cache-Control' => 'max-age=0, no-store, no-cache' );
+        $c->res->body($stdout);
+
+    }
+    else {
+
+        # browser cache
+        $c->res->header( 'Cache-Control' => 'max-age=' . $c->one_hour );
+        $c->res->body( CSS::Minifier::XS::minify($stdout) );
+
+    }
+}
+
+sub js : Path('mc.js') : Args(0) {
+    my ( $self, $c ) = @_;
+
+    $c->res->content_type('application/javascript');
+
+    my @js_files = map {"root/static/js/$_.js"} (
+        qw(
+            jquery.min
+            jquery.tablesorter
+            jquery.relatize_date
+            jquery.qtip.min
+            jquery.autocomplete.min
+            mousetrap.min
+            shCore
+            shBrushPerl
+            shBrushPlain
+            shBrushYaml
+            shBrushJScript
+            shBrushDiff
+            shBrushCpp
+            shBrushCPANChanges
+            cpan
+            toolbar
+            github
+            contributors
+            dropdown
+            bootstrap/bootstrap-dropdown
+            bootstrap/bootstrap-collapse
+            bootstrap/bootstrap-modal
+            bootstrap/bootstrap-tooltip
+            bootstrap/bootstrap-affix
+            bootstrap-slidepanel
+            syntaxhighlighter
+            ),
+    );
+
+    my $out;
+    local $/ = undef;
+    foreach my $file (@js_files) {
+        open my $fh, "<", $file
+            or die "could not open $file: $!";
+        my $content = <$fh>;
+        close($fh);
+
+        if ( string_has_bom($content) ) {
+            $content = strip_bom_from_string($content);
+        }
+        $out .= "\n/* $file */\n";
+        $out .= $content;
+    }
+
+    # cdn cache
+    $c->add_surrogate_key('assets');
+    $c->add_surrogate_key('js');
+    $c->cdn_cache_ttl( $c->one_month );    # 30 days
+
+    if ( $ENV{PLACK_ENV} && $ENV{PLACK_ENV} eq 'development' ) {
+
+        # Make sure the user re-requests each time
+        $c->res->header( 'Cache-Control' => 'max-age=0, no-store, no-cache' );
+        $c->res->body( JavaScript::Minifier::XS::minify($out) );
+
+    }
+    else {
+
+        # browser cache
+        $c->res->header( 'Cache-Control' => 'max-age=' . $c->one_hour );
+        $c->res->body( JavaScript::Minifier::XS::minify($out) );
+
+    }
+}
+
+1;

--- a/lib/MetaCPAN/Web/Controller/Assets.pm
+++ b/lib/MetaCPAN/Web/Controller/Assets.pm
@@ -36,8 +36,11 @@ sub css : Path('style.css') : Args(0) {
     my $less = `lessc -v`;
     croak(q{Can't find lessc command}) unless $less;
 
+    my @cmd
+        = ( 'lessc', '--include-path=root/static/less:root/static/', $file );
+
     my ( $stdout, $stderr, $exit ) = capture {
-        system( 'lessc', $file );
+        system(@cmd);
     };
     die $stderr if $stderr;
 
@@ -50,7 +53,7 @@ sub css : Path('style.css') : Args(0) {
 
         # Make sure the user re-requests each time
         $c->res->header( 'Cache-Control' => 'max-age=0, no-store, no-cache' );
-        $c->res->body($stdout);
+        $c->res->body( CSS::Minifier::XS::minify($stdout) );
 
     }
     else {

--- a/lib/MetaCPAN/Web/Role/Fastly.pm
+++ b/lib/MetaCPAN/Web/Role/Fastly.pm
@@ -39,6 +39,18 @@ has '_surrogate_keys_to_purge' => (
     },
 );
 
+sub one_hour {
+    return 3200;
+}
+
+sub one_day {
+    return 86_400;
+}
+
+sub one_month {
+    return 2_592_000;
+}
+
 sub _net_fastly {
     my $c = shift;
 

--- a/root/static/css/user.css
+++ b/root/static/css/user.css
@@ -1,9 +1,0 @@
-/* Specific css for User actions */
-
-.logged_in {
-   display: none;
-}
-
-.logged_out {
-   display: none;
-}

--- a/root/static/less/login.less
+++ b/root/static/less/login.less
@@ -11,3 +11,13 @@
         font-size: 2.7em;
     }
 }
+
+/* Specific css for User actions */
+
+.logged_in {
+   display: none;
+}
+
+.logged_out {
+   display: none;
+}

--- a/root/static/less/style.less
+++ b/root/static/less/style.less
@@ -1,3 +1,9 @@
+// Libraries that are not less
+@import (inline) "css/jquery.autocomplete.css";
+@import (inline) "css/shCore.css";
+@import (inline) "css/jquery.qtip.min.css";
+@import (inline) "css/shThemeDefault.css";
+
 @import "bootstrap/bootstrap.less";
 @import "font-awesome/font-awesome.less";
 

--- a/root/wrapper.html
+++ b/root/wrapper.html
@@ -41,9 +41,9 @@
         <%- IF rss %>
         <link rel="alternate" type="application/rss+xml" title="RSS" href="https://metacpan.org/feed/<% rss %>" />
         <% END %>
-        <%- FOREACH css IN req.env.item('psgix.assets').grep(/\.css$/) %>
-        <link href="<% css %>" rel="stylesheet" type="text/css">
-        <%- END %>
+        <%-# FOREACH css IN req.env.item('psgix.assets').grep(/\.css$/) %>
+        <link href="/assets/style.css" rel="stylesheet" type="text/css">
+        <%-# END %>
         <link rel="search" href="/static/opensearch.xml" type="application/opensearchdescription+xml" title="MetaCPAN">
         <%- IF canonical %>
         <link rel="canonical" href="https://metacpan.org<% canonical %>" />
@@ -53,13 +53,9 @@
         <%- END %>
         <link rel="shortcut icon" href="/static/icons/favicon.ico">
         <link rel="apple-touch-icon" sizes="152x152" href="/static/icons/apple-touch-icon.png">
-        <%- FOREACH js IN req.env.item('psgix.assets').grep(/\.js$/) %>
-        <script src="<% js %>" type="text/javascript"></script>
-        <%- END %>
-        <% IF PLACK_ENV == 'development' %>
-        <link rel="stylesheet/less" type="text/css" href="/static/less/style.less">
-        <script src="/static/js/less.min.js" type="text/javascript"></script>
-        <% END %>
+        <%-# FOREACH js IN req.env.item('psgix.assets').grep(/\.js$/) %>
+        <script src="/assets/mc.js" type="text/javascript"></script>
+        <%-# END %>
         <script>
           (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
           (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
Move js and css to fixed URL's (e.g. no md5... so works with cached pages), move lessc to server side and dynamic (also faster for development IMHO)

We'll delete fastly cache when we do a deploy (fastly setup to cache for 30 days), and users can cache for an hour