### PR TITLE
URI escape fabricated RT urls

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -86,6 +86,7 @@ requires 'Text::Pluralize';
 requires 'Try::Tiny', '0.09';
 requires 'YAML', '1.15'; # fix dep chain issue
 requires 'URI';
+requires 'URI::Escape';
 requires 'XML::Feed';
 requires 'XML::Simple';
 

--- a/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
+++ b/lib/MetaCPAN/Web/Model/ReleaseInfo.pm
@@ -187,7 +187,8 @@ sub normalize_issues {
         $issues->{url} = 'mailto:' . $bugtracker->{mailto};
     }
     else {
-        $issues->{url} = $self->rt_url_prefix . $release->{distribution};
+        $issues->{url}
+            = $self->rt_url_prefix . uri_escape( $release->{distribution} );
     }
 
     if ( my $bugs = $distribution->{bugs} ) {


### PR DESCRIPTION
This apparently does *not* come from the distribution endpoint.

refs #1577.