### PR TITLE
Json view errors

### DIFF
--- a/lib/MetaCPAN/Web/View/JSON.pm
+++ b/lib/MetaCPAN/Web/View/JSON.pm
@@ -1,8 +1,14 @@
 package MetaCPAN::Web::View::JSON;
 
 use Moose;
+use JSON::MaybeXS ();
 
 extends 'Catalyst::View::JSON';
+
+sub encode_json {
+    my ( $self, $c, $data ) = @_;
+    JSON::MaybeXS->new->utf8->encode($data);
+}
 
 # Catalyst::View::JSON is not a Moose.
 __PACKAGE__->meta->make_immutable( inline_constructor => 0 );

--- a/t/lib/MetaCPAN/Web/Controller/Test.pm
+++ b/t/lib/MetaCPAN/Web/Controller/Test.pm
@@ -1,0 +1,23 @@
+package MetaCPAN::Web::Controller::Test;
+
+use Moose;
+BEGIN { extends 'MetaCPAN::Web::Controller' }
+
+sub _json_body {
+    my ( $self, $c ) = @_;
+    JSON::MaybeXS->new->utf8->decode(
+        do { local $/; $c->req->body->getline }
+    );
+}
+
+sub json_echo : Local {
+    my ( $self, $c ) = @_;
+
+    $c->stash->{echo} = $self->_json_body($c);
+
+    $c->detach( $c->view('JSON') );
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/t/view/json.t
+++ b/t/view/json.t
@@ -1,0 +1,53 @@
+use strict;
+use warnings;
+use lib 't/lib';
+use Test::More;
+use HTTP::Request::Common 'POST';
+use MetaCPAN::Web::Test;
+use JSON::MaybeXS;
+
+sub post_json {
+    POST(
+        shift(),
+        Content      => shift(),
+        Content_type => 'application/json',
+        @_
+    );
+}
+
+my $cb;
+
+sub echo_json_ok {
+    my ( $json, $desc ) = @_;
+
+    subtest $desc => sub {
+        my $exp = decode_json($json);
+
+        ok( my $res = $cb->( post_json '/test/json_echo', $json ),
+            'http post' );
+        is( $res->code, 200, '200 OK' );
+
+        my $res_json = $res->content;
+        ok( my $obj = eval { decode_json($res_json); }, 'decode json' );
+
+        note "received: $res_json";
+
+        is_deeply $obj, { echo => $exp }, "json passed through unchanged";
+    };
+}
+
+test_psgi app, sub {
+    $cb = shift;    # global
+};
+
+{
+
+    echo_json_ok( q!{"test": 1}!, 'minimal json' );
+
+    echo_json_ok( q!{"test": [1, 2, {"hash": {}}] }!, 'arrays and hashes' );
+
+    local $TODO = 'errors encoding boolean objects';
+    echo_json_ok( q!{"test": true}!, 'booleans' );
+}
+
+done_testing;

--- a/t/view/json.t
+++ b/t/view/json.t
@@ -46,7 +46,6 @@ test_psgi app, sub {
 
     echo_json_ok( q!{"test": [1, 2, {"hash": {}}] }!, 'arrays and hashes' );
 
-    local $TODO = 'errors encoding boolean objects';
     echo_json_ok( q!{"test": true}!, 'booleans' );
 }
 


### PR DESCRIPTION
Ever since we added the `favorites_as_json` thing i've been seeing a 500 Error in my console about it.
I noticed this week that it is actually killing the Account menu for me.
I **am** logged in, but b/c the json call fails, the javascript shows me the "Sign in" menu, which is very confusing.

I noticed an error in the log:
```
[error] Caught exception in MetaCPAN::Web::View::JSON->process "encountered object 'true', but neither allow_blessed, convert_blessed nor all
ow_tags settings are enabled (or TO_JSON/FREEZE method missing) at (eval 891) line 151."
```

and tracked it down to the fact that my user profile has booleans in the "extra" data.