### PR TITLE
Use containers and build caching on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,6 @@ notifications:
     on_success: change
     on_failure: always
   irc: "irc.perl.org#metacpan-travis"
+
+# Use newer travis infrastructure.
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: perl
 perl:
+  # as of 2015-08-23 travis doesn't have 5.22
   - "5.20"
   - "5.18"
   - "5.16"
 
 matrix:
   allow_failures:
-    - perl: "5.20"
+    - perl: "5.22"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,6 @@ notifications:
 
 # Use newer travis infrastructure.
 sudo: false
+cache:
+  directories:
+    - local


### PR DESCRIPTION
Use newer container-based infrastructure and cache the `local::lib` to save 10 minutes off each build.
