### PR TITLE
Replace MetaCPAN Helper with MetaCPAN redirect

### DIFF
--- a/root/about/faq.html
+++ b/root/about/faq.html
@@ -109,7 +109,7 @@ we can push the right buttons to have your work removed from MetaCPAN as well.
 ## Can I _automatically_ redirect links pointing at search.cpan.org to metacpan.org?
 
 For Chrome users, the [MetaCPAN
-Helper](https://chrome.google.com/webstore/detail/metacpan-helper/aoioenbjpmccpkincghhjfmeceknpcnb)
+redirect](https://chrome.google.com/webstore/detail/metacpan-redirect/ojemidgoiffinacbckopjjndlobmgpmk)
 extension will automatically rewrite search.cpan.org links to MetaCPAN.
 
 You can accomplish the same thing by modifying your <code>hosts</code> file


### PR DESCRIPTION
[Reviews](https://chrome.google.com/webstore/detail/metacpan-helper/aoioenbjpmccpkincghhjfmeceknpcnb/reviews) says that old chrome extension does not seem to work. Link to source code is [broken](https://github.com/worr/metacpan-ext).