### PR TITLE
Fix json/utf8 en/de-coding in profile.extra

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Account.pm
+++ b/lib/MetaCPAN/Web/Controller/Account.pm
@@ -82,9 +82,9 @@ sub profile : Local {
     $data->{$_} = $req->params->{$_} eq q{} ? undef : $req->params->{$_}
         for (qw(name asciiname gravatar_url city region country));
     $data->{$_} = [ grep {$_} $req->param($_) ] for (qw(website email));
-    $data->{extra} = eval {
-        JSON::MaybeXS->new->relaxed->utf8->decode( $req->params->{extra} );
-    };
+
+    $data->{extra} = $req->json_param('extra');
+
     $data->{donation} = undef unless ( $req->params->{donations} );
 
     my $res

--- a/lib/MetaCPAN/Web/Role/Request.pm
+++ b/lib/MetaCPAN/Web/Role/Request.pm
@@ -1,9 +1,13 @@
 package MetaCPAN::Web::Role::Request;
 
+use utf8;
 use Moose::Role;
 use Plack::Session;
-
+use JSON::MaybeXS ();
 use MetaCPAN::Web::Types qw( PositiveInt );
+use Try::Tiny;
+
+use namespace::autoclean;
 
 sub page {
     my $page = shift->parameters->{p};
@@ -24,6 +28,23 @@ sub get_page_size {
         $page_size = $default_page_size;
     }
     return $page_size;
+}
+
+sub json_param {
+    my ( $self, $name ) = @_;
+    return try {
+        JSON::MaybeXS->new->relaxed->utf8( $self->params_are_decoded ? 0 : 1 )
+            ->decode( $self->params->{$name} );
+    }
+    catch {
+        warn "Failed to decode JSON: $_[0]";
+        undef;
+    };
+}
+
+sub params_are_decoded {
+    my ($self) = @_;
+    return $self->params->{utf8} eq "🐪";
 }
 
 1;

--- a/lib/MetaCPAN/Web/View/HTML.pm
+++ b/lib/MetaCPAN/Web/View/HTML.pm
@@ -90,7 +90,9 @@ Template::Alloy->define_vmethod( 'text',
 Template::Alloy->define_vmethod(
     'hash',
     pretty_json => sub {
-        JSON::MaybeXS->new->utf8->pretty->encode(shift);
+
+    # Use utf8(0) because Catatlyst expects our view to be a character string.
+        JSON::MaybeXS->new->utf8(0)->pretty->encode(shift);
     }
 );
 

--- a/root/account/profile.html
+++ b/root/account/profile.html
@@ -6,7 +6,8 @@
       In order to change your profile you have to <a href="<% oauth_prefix %>&amp;choice=pause" onclick="return logInPAUSE(this)">connect your account to PAUSE</a>.
     </div>
     <% ELSE -%>
-    <form method="POST" action="" class="form-horizontal" role="form" id="account-profile">
+    <form method="POST" action="" class="form-horizontal" role="form" id="account-profile" accept-charset="utf-8">
+        <% utf8_form_input | none %>
         <% IF errors -%>
         <fieldset><legend style="color: #600">Errors</legend>
             <ul>

--- a/root/preprocess.html
+++ b/root/preprocess.html
@@ -53,6 +53,8 @@ profiles = {
   vimeo = { name = 'Vimeo', url = 'http://vimeo.com/%s' },
   youtube = { name = 'Youtube', url = 'http://www.youtube.com/user/%s' },
   };
+
+  utf8_form_input = '<input type="hidden" name="utf8" value="🐪" />';
 -%>
 <%-
 

--- a/t/controller/account.t
+++ b/t/controller/account.t
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+use Test::More;
+
+local $TODO = 'Write account tests';
+ok 0, 'no tests';
+
+done_testing;


### PR DESCRIPTION
I believe this fixes #1562.
We're applying the typical utf8 json handling when Catalyst is already doing the en/de-coding, so everything is doubled.