### PR TITLE
Add link to expand and collapse long change lists

### DIFF
--- a/root/release.html
+++ b/root/release.html
@@ -82,7 +82,10 @@ documentation = documentation.merge(documentation_raw);
 
 <div class="last-changes well">
     <h2 id="whatsnew">Changes for version <% last_version_changes.version %></h2>
-    <% change_group(last_version_changes.entries) | none %>
+    <div class="change-entries">
+        <% change_group(last_version_changes.entries) | none %>
+    </div>
+    <a id="whatsnew-toggle-overflow">Show More</a>
 </div>
 
 <%- END %>

--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -89,6 +89,19 @@ function toggleTOC() {
     return false;
 }
 
+function toggleWhatsnew() {
+    var changes = $('.last-changes .change-entries');
+    var link = $('.last-changes #whatsnew-toggle-overflow');
+
+    if (link.text() == 'Show Less') {
+        changes.css('max-height', '19.5em');
+        link.text('Show More');
+    } else {
+        changes.css('max-height', 'none');
+        link.text('Show Less');
+    }
+}
+
 $(document).ready(function() {
 
     // User customisations
@@ -409,6 +422,15 @@ $(document).ready(function() {
     set_page_size('a[href*="/releases"]', 'releases_page_size');
     set_page_size('a[href*="/recent"]', 'recent_page_size');
     set_page_size('a[href*="/requires"]', 'requires_page_size');
+
+    var changes = $('.last-changes .change-entries');
+    if (changes.prop('scrollHeight') > changes.height()) {
+      $('#whatsnew-toggle-overflow').on('click', function() {
+        toggleWhatsnew();
+      });
+    } else {
+      $('#whatsnew-toggle-overflow').hide();
+    }
 
 });
 

--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -425,11 +425,11 @@ $(document).ready(function() {
 
     var changes = $('.last-changes .change-entries');
     if (changes.prop('scrollHeight') > changes.height()) {
-      $('#whatsnew-toggle-overflow').on('click', function() {
-        toggleWhatsnew();
-      });
+        $('#whatsnew-toggle-overflow').on('click', function() {
+            toggleWhatsnew();
+        });
     } else {
-      $('#whatsnew-toggle-overflow').hide();
+        $('#whatsnew-toggle-overflow').hide();
     }
 
 });

--- a/root/static/less/release.less
+++ b/root/static/less/release.less
@@ -49,5 +49,14 @@
         }
     }
 
+    .change-entries {
+        max-height: 19.5em;
+        overflow-y: hidden;
+    }
+
+    #whatsnew-toggle-overflow {
+        margin-top: 1em;
+    }
+
     margin-right: 200px;
 }


### PR DESCRIPTION
Adds a link to expand and collapse large whatsnew sections.  The link text is hardcoded to be "Show More" and "Show Less" because I couldn't figure out how/if any internationalization code worked.  Some animation would make this look much nice, but I lack the jQuery/CSS chops for that.