### PR TITLE
Remove coderwall endorse button.

### DIFF
--- a/root/inc/author-pic.html
+++ b/root/inc/author-pic.html
@@ -32,6 +32,9 @@
   <a rel="author" href="/author/<% author.pauseid %>"><% author.pauseid %></a>
 </strong>
 <span title="<% author.asciiname %>"><% author.name %></span>
+<%-
+   FOREACH p IN author.profile;
+-%>
 <% IF p.name == "googleplus" %>
   <a rel="author" href="<% profiles.${p.name}.url.replace('%s', p.id) %>?rel=author" target="_blank" title="<% p.name %> - <% p.id%>" style="display: none;">
     <img src="/static/images/profile/<% p.name %>.png" width=16 height=16 alt="<% p.name %>">

--- a/root/inc/author-pic.html
+++ b/root/inc/author-pic.html
@@ -32,17 +32,6 @@
   <a rel="author" href="/author/<% author.pauseid %>"><% author.pauseid %></a>
 </strong>
 <span title="<% author.asciiname %>"><% author.name %></span>
-<%-
-  FOREACH p IN author.profile;
-  IF p.name == 'coderwall';
-%>
-  <div class="coderwall">
-    <a href="https://coderwall.com/<% p.id %>">
-        <img alt="Endorse <% author.asciiname %> on Coderwall"
-           title="Endorse <% author.asciiname %> on Coderwall"
-             width="110" height="20"
-             src="https://api.coderwall.com/<% p.id %>/endorsecount.png" /></a></div>
-<% END %>
 <% IF p.name == "googleplus" %>
   <a rel="author" href="<% profiles.${p.name}.url.replace('%s', p.id) %>?rel=author" target="_blank" title="<% p.name %> - <% p.id%>" style="display: none;">
     <img src="/static/images/profile/<% p.name %>.png" width=16 height=16 alt="<% p.name %>">

--- a/root/static/less/author.less
+++ b/root/static/less/author.less
@@ -54,12 +54,6 @@
 
 @media (max-width: 480px) {
     .author-pic {
-
-        .coderwall img {
-            width: 55px;
-            height: 10px;
-        }
-
         > a {
             > img {
                 width: 65px;


### PR DESCRIPTION
The coderwall API for this image seems to break once a year or so.
Nobody on their end notices until I poke them on Twitter, so I assume it
doesn't really get used all that much.  I also don't think people on the
MetaCPAN side really use it either.