### PR TITLE
Show changelogs since last stable

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Release.pm
+++ b/lib/MetaCPAN/Web/Controller/Release.pm
@@ -131,8 +131,14 @@ sub view : Private {
                 qw( mark_unauthorized_releases )
         ),
 
-        ( $changes ? ( last_version_changes => $changes ) : () )
-
+        (
+            @$changes
+            ? (
+                last_version_changes => $changes->[0],
+                changelogs           => $changes,
+                )
+            : ()
+        )
     );
 }
 

--- a/lib/MetaCPAN/Web/Model/API/Changes.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes.pm
@@ -28,20 +28,43 @@ sub last_version {
             warn "Error parsing changes: $_" if $ENV{CATALYST_DEBUG};
         };
     }
-    return unless $releases && @$releases;
+    return [] unless $releases && @$releases;
 
-    # Ok, lets make sure we get the right release..
-    my $changelog = $self->find_changelog( $release->{version}, $releases );
+    my @releases = sort { $b->[0] <=> $a->[0] }
+        map {
+        my $v = $_->{version};
+        $v =~ s/-TRIAL$//;
+        my $dev = $_->{version} =~ /_|-TRIAL$/;
+        [ version->parse($v), $v, $dev, $_ ];
+        } @$releases;
 
-    return unless $changelog;
-    return $self->filter_release_changes( $changelog, $release );
+    my @changelogs;
+    my $found;
+    for my $r (@releases) {
+        if ($found) {
+            if ( $r->[2] ) {
+                push @changelogs, $r->[3];
+            }
+            else {
+                last;
+            }
+        }
+        elsif ( $r->[0] eq $release->{version} ) {
+            push @changelogs, $r->[3];
+            $found = 1;
+        }
+    }
+    return [ map { $self->filter_release_changes( $_, $release ) }
+            @changelogs ];
 }
 
 sub find_changelog {
     my ( $self, $version, $releases ) = @_;
 
     foreach my $rel (@$releases) {
-        return $rel if ( $rel->{version} eq $version || $rel->{version} eq "$version-TRIAL" );
+        return $rel
+            if ( $rel->{version} eq $version
+            || $rel->{version} eq "$version-TRIAL" );
     }
 }
 

--- a/lib/MetaCPAN/Web/Model/API/Changes.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes.pm
@@ -41,7 +41,7 @@ sub find_changelog {
     my ( $self, $version, $releases ) = @_;
 
     foreach my $rel (@$releases) {
-        return $rel if ( $rel->{version} eq $version );
+        return $rel if ( $rel->{version} eq $version || $rel->{version} eq "$version-TRIAL" );
     }
 }
 

--- a/lib/MetaCPAN/Web/Model/API/Changes/Parser.pm
+++ b/lib/MetaCPAN/Web/Model/API/Changes/Parser.pm
@@ -27,7 +27,9 @@ sub parse {
     my @indents;
     for my $linenr ( 0 .. $#lines ) {
         my $line = $lines[$linenr];
-        if ( $line =~ /^(?:version\s+)?($version::LAX)(\s+(.*))?$/i ) {
+        if ( $line
+            =~ /^(?:version\s+)?($version::LAX(?:-TRIAL)?)(\s+(.*))?$/i )
+        {
             my $version = $1;
             my $note    = $3;
             if ($note) {

--- a/root/release.html
+++ b/root/release.html
@@ -82,10 +82,12 @@ documentation = documentation.merge(documentation_raw);
 
 <div id="last-changes" class="well collapsed">
     <div id="last-changes-container">
-        <h2 id="whatsnew">Changes for version <% last-changes-container.version %></h2>
+        <%- FOREACH changes IN changelogs %>
+        <h2 id="whatsnew">Changes for version <% changes.version %></h2>
         <div class="change-entries">
-            <% change_group(last-changes-container.entries) | none %>
+            <% change_group(changes.entries) | none %>
         </div>
+        <%- END %>
     </div>
     <button id="last-changes-toggle" class="btn-link" onclick="$('#last-changes').toggleClass('collapsed'); return false;">[ <span class="hide-more">Hide More</span><span class="show-more">Show More</span> ]</button>
 </div>

--- a/root/release.html
+++ b/root/release.html
@@ -78,14 +78,16 @@ documentation = documentation.merge(documentation_raw);
 </ul>
 <% END %>
 
-<%- IF last_version_changes %>
+<%- IF changelogs %>
 
-<div class="last-changes well">
-    <h2 id="whatsnew">Changes for version <% last_version_changes.version %></h2>
-    <div class="change-entries">
-        <% change_group(last_version_changes.entries) | none %>
+<div id="last-changes" class="well collapsed">
+    <div id="last-changes-container">
+        <h2 id="whatsnew">Changes for version <% last-changes-container.version %></h2>
+        <div class="change-entries">
+            <% change_group(last-changes-container.entries) | none %>
+        </div>
     </div>
-    <a id="whatsnew-toggle-overflow">Show More</a>
+    <button id="last-changes-toggle" class="btn-link" onclick="$('#last-changes').toggleClass('collapsed'); return false;">[ <span class="hide-more">Hide More</span><span class="show-more">Show More</span> ]</button>
 </div>
 
 <%- END %>

--- a/root/static/js/cpan.js
+++ b/root/static/js/cpan.js
@@ -89,19 +89,6 @@ function toggleTOC() {
     return false;
 }
 
-function toggleWhatsnew() {
-    var changes = $('.last-changes .change-entries');
-    var link = $('.last-changes #whatsnew-toggle-overflow');
-
-    if (link.text() == 'Show Less') {
-        changes.css('max-height', '19.5em');
-        link.text('Show More');
-    } else {
-        changes.css('max-height', 'none');
-        link.text('Show Less');
-    }
-}
-
 function setFavTitle(button) {
     button.attr('title', button.hasClass('active') ? 'Remove from favorite' : 'Add to favorite');
     return;
@@ -410,15 +397,10 @@ $(document).ready(function() {
     set_page_size('a[href*="/recent"]', 'recent_page_size');
     set_page_size('a[href*="/requires"]', 'requires_page_size');
 
-    var changes = $('.last-changes .change-entries');
+    var changes = $('#last-changes-container');
     if (changes.prop('scrollHeight') > changes.height()) {
-        $('#whatsnew-toggle-overflow').on('click', function() {
-            toggleWhatsnew();
-        });
-    } else {
-        $('#whatsnew-toggle-overflow').hide();
+        $("#last-changes-toggle").show();
     }
-
 });
 
 function set_page_size(selector, storage_name) {

--- a/root/static/less/release.less
+++ b/root/static/less/release.less
@@ -29,14 +29,12 @@
 /* Changes in release page
  * See /release/CPAN-Changes for example
  */
-.last-changes {
+#last-changes {
     h2:extend(.content .file-group h2) {}
+
     ul {
         margin-bottom: 1em;
         padding-left: 20px;
-    }
-    > ul:last-child {
-        margin-bottom: 0;
     }
 
     ul, ul ul ul {
@@ -46,25 +44,28 @@
         list-style: circle;
     }
 
-    > ul > .group-header {
-        list-style: none;
-        > .change-entry {
-            font-weight: bold;
-        }
-    }
-
     .change-entries {
-        max-height: 19.5em;
-        overflow-y: hidden;
-
-        > ul:last-child {
-            margin-bottom: 0;
+        margin-bottom: 0.5em;
+        &:last-child {
+            margin-bottom: 0em;
         }
     }
 
-    #whatsnew-toggle-overflow {
-        margin-top: 1em;
+    .show-more { display: none }
+    .hide-more { display: inline }
+    &.collapsed {
+        .show-more { display: inline }
+        .hide-more { display: none }
+        #last-changes-container {
+            overflow: hidden;
+            max-height: 19.5em;
+        }
     }
 
-    margin-right: 200px;
+    #last-changes-toggle {
+        display: none;
+    }
+
+    padding-bottom: .5em;
+    overflow: auto;
 }


### PR DESCRIPTION
This causes metacpan to show all changelog entries since the last stable release.  Also fixes the handling of -TRIAL releases, and has a cleanup of the show/hide mechanism.

Fixes #1624 and #1671.