### PR TITLE
Have both CPAN author directory link and BackPAN author directory link

### DIFF
--- a/root/author.html
+++ b/root/author.html
@@ -138,7 +138,10 @@
         <a href="https://explorer.metacpan.org/?url=/author/<% author.pauseid %>">MetaCPAN Explorer</a>
     </li>
     <li>
-        <a href="https://cpan.metacpan.org/authors/id/<% author.pauseid.substr(0,1) %>/<% author.pauseid.substr(0,2) %>/<% author.pauseid %>/">Browse CPAN directory</a>
+        <a href="http://cpan.org/authors/id/<% author.pauseid.substr(0,1) %>/<% author.pauseid.substr(0,2) %>/<% author.pauseid %>/">Browse CPAN directory</a>
+    </li>
+    <li>
+        <a href="https://cpan.metacpan.org/authors/id/<% author.pauseid.substr(0,1) %>/<% author.pauseid.substr(0,2) %>/<% author.pauseid %>/" title="See all releases ever done by <% author.pauseid %>, not just those currently on CPAN.">Browse BackPAN directory</a>
     </li>
 </ul>
 <!-- End left content -->


### PR DESCRIPTION
Update author page to have links to both the author's current CPAN author directory (their releases that are still on CPAN) and their BackPAN directory (all releases ever done).

I often want to look at both of these places, and always end up typing the URLs directly. This will save me some typing :-)
