### PR TITLE
Moved Elasticsearch::Adapter (single_valued_arrayref_to_scalar)

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -43,6 +43,7 @@ requires 'HTTP::Request';
 requires 'HTTP::Request::Common';
 requires 'Hash::AsObject';
 requires 'Hash::Merge';
+requires 'Importer';
 requires 'JavaScript::Minifier::XS';
 requires 'JSON::MaybeXS', '1.002000';
 requires 'List::AllUtils';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -2416,6 +2416,13 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
+  Importer-0.012
+    pathname: E/EX/EXODIST/Importer-0.012.tar.gz
+    provides:
+      Importer 0.012
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.008001
   JSON-2.90
     pathname: M/MA/MAKAMAKA/JSON-2.90.tar.gz
     provides:

--- a/lib/MetaCPAN/Web/Controller.pm
+++ b/lib/MetaCPAN/Web/Controller.pm
@@ -4,10 +4,6 @@ use namespace::autoclean;
 
 BEGIN { extends 'Catalyst::Controller'; }
 
-# For elasticsearch 1.x changes in the structure returned in the fields of {hits}{hits}
-# See: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/_return_values.html
-with('MetaCPAN::Web::Role::Elasticsearch::Adapter');
-
 __PACKAGE__->meta->make_immutable;
 
 1;

--- a/lib/MetaCPAN/Web/Controller/Author.pm
+++ b/lib/MetaCPAN/Web/Controller/Author.pm
@@ -7,6 +7,9 @@ use DateTime::Format::ISO8601 ();
 use namespace::autoclean;
 use Locale::Country ();
 
+use Importer 'MetaCPAN::Web::Elasticsearch::Adapter' =>
+    qw/ single_valued_arrayref_to_scalar /;
+
 BEGIN { extends 'MetaCPAN::Web::Controller' }
 
 # Capture the PAUSE id in the root of the chain so we handle the upper-case redirect once.
@@ -59,12 +62,12 @@ sub index : Chained('root') PathPart('') Args(0) {
         $took += $faves_data->{took} || 0;
 
         $faves = [ map { $_->{fields} } @{ $faves_data->{hits}->{hits} } ];
-        $self->single_valued_arrayref_to_scalar($faves);
+        single_valued_arrayref_to_scalar($faves);
         $faves = [ sort { $b->{date} cmp $a->{date} } @{$faves} ];
     }
 
     my $releases = [ map { $_->{fields} } @{ $data->{hits}->{hits} } ];
-    $self->single_valued_arrayref_to_scalar($releases);
+    single_valued_arrayref_to_scalar($releases);
     my $date = List::Util::max
         map { DateTime::Format::ISO8601->parse_datetime( $_->{date} ) }
         @$releases;

--- a/lib/MetaCPAN/Web/Controller/Feed.pm
+++ b/lib/MetaCPAN/Web/Controller/Feed.pm
@@ -10,6 +10,9 @@ use DateTime::Format::ISO8601;
 use Path::Tiny qw/path/;
 use Text::Markdown qw/markdown/;
 
+use Importer 'MetaCPAN::Web::Elasticsearch::Adapter' =>
+    qw/ single_valued_arrayref_to_scalar /;
+
 sub recent : Local : Args(0) {
     my ( $self, $c ) = @_;
     $c->forward('/recent/index');
@@ -109,7 +112,7 @@ sub distribution : Local : Args(1) {
 
 sub build_entry {
     my ( $self, $entry ) = @_;
-    $self->single_valued_arrayref_to_scalar($entry);
+    single_valued_arrayref_to_scalar($entry);
     my $e = XML::Feed::Entry->new('RSS');
     $e->title( $entry->{name} );
     $e->link(

--- a/lib/MetaCPAN/Web/Controller/Recent.pm
+++ b/lib/MetaCPAN/Web/Controller/Recent.pm
@@ -1,5 +1,9 @@
 package MetaCPAN::Web::Controller::Recent;
 use Moose;
+
+use Importer 'MetaCPAN::Web::Elasticsearch::Adapter' =>
+    qw/ single_valued_arrayref_to_scalar /;
+
 BEGIN { extends 'MetaCPAN::Web::Controller' }
 
 sub index : Path : Args(0) {
@@ -12,7 +16,7 @@ sub index : Path : Args(0) {
         = $c->model('API::Release')
         ->recent( $req->page, $page_size, $req->params->{f} || 'l' )->recv;
     my $latest = [ map { $_->{fields} } @{ $data->{hits}->{hits} } ];
-    $self->single_valued_arrayref_to_scalar($latest);
+    single_valued_arrayref_to_scalar($latest);
     $c->res->last_modified( $latest->[0]->{date} ) if (@$latest);
     $c->stash(
         {

--- a/lib/MetaCPAN/Web/Controller/Search/AutoComplete.pm
+++ b/lib/MetaCPAN/Web/Controller/Search/AutoComplete.pm
@@ -2,6 +2,10 @@ package MetaCPAN::Web::Controller::Search::AutoComplete;
 
 use Moose;
 use JSON::MaybeXS ();
+
+use Importer 'MetaCPAN::Web::Elasticsearch::Adapter' =>
+    qw/ single_valued_arrayref_to_scalar /;
+
 use namespace::autoclean;
 
 BEGIN { extends 'MetaCPAN::Web::Controller' }
@@ -14,7 +18,7 @@ sub index : Path : Args(0) {
     $c->res->content_type('application/json');
     $c->res->body(
         JSON::MaybeXS::encode_json(
-            $self->single_valued_arrayref_to_scalar( $data->{results} )
+            single_valued_arrayref_to_scalar( $data->{results} )
         )
     );
 }

--- a/lib/MetaCPAN/Web/Elasticsearch/Adapter.pm
+++ b/lib/MetaCPAN/Web/Elasticsearch/Adapter.pm
@@ -1,8 +1,8 @@
-package MetaCPAN::Web::Role::Elasticsearch::Adapter;
-
-use Moose::Role;
+package MetaCPAN::Web::Elasticsearch::Adapter;
 
 use Ref::Util qw( is_arrayref );
+
+our @EXPORT_OK = qw( single_valued_arrayref_to_scalar );
 
 =head1 METHODS
 
@@ -62,7 +62,7 @@ yields:
 =cut
 
 sub single_valued_arrayref_to_scalar {
-    my ( $self, $array, $fields ) = @_;
+    my ( $array, $fields ) = @_;
     my $is_arrayref = is_arrayref($array);
 
     $array = [$array] unless $is_arrayref;
@@ -81,48 +81,6 @@ sub single_valued_arrayref_to_scalar {
         }
     }
     return $is_arrayref ? $array : @{$array};
-}
-
-=head2 scalar_to_single_valued_arrayref
-
-Given an ArrayRef[HashRef[Str]], turn all scalar values of the HashRef
-into a single valued ArrayRef, i.e. a ArrayRef[HashRef[ArrayRef[Str]]]
-
-So this:
-
-    [
-      {
-        distribution => 'WhizzBang',
-        provides     => ['Food', 'Bar'],
-      },
-       ...
-   ]
-
-becomes:
-
-    [
-      {
-        distribution => ['WhizzBang'],
-        provides       => ['Food, 'Bar'],
-      },
-      ...
-    ]
-
-
-=cut
-
-sub scalar_to_single_valued_arrayref {
-    my ( $self, $array ) = @_;
-    foreach my $hash ( @{$array} ) {
-        foreach my $field ( %{$hash} ) {
-            my $value = $hash->{$field};
-
-            # Move on if we already have a ref
-            next if ref($value);
-            $hash->{$field} = [$value];
-        }
-    }
-    return $array;
 }
 
 1;

--- a/lib/MetaCPAN/Web/Role/ReleaseInfo.pm
+++ b/lib/MetaCPAN/Web/Role/ReleaseInfo.pm
@@ -2,6 +2,9 @@ package MetaCPAN::Web::Role::ReleaseInfo;
 
 use Moose::Role;
 
+use Importer 'MetaCPAN::Web::Elasticsearch::Adapter' =>
+    qw/ single_valued_arrayref_to_scalar /;
+
 # TODO: are there other controllers that do (or should) include this?
 
 # TODO: should some of this be in a separate (instantiable) model
@@ -56,7 +59,7 @@ sub stash_api_results {
     );
 
     my %stash
-        = map { $_ => $self->single_valued_arrayref_to_scalar( $to_stash{$_} ) }
+        = map { $_ => single_valued_arrayref_to_scalar( $to_stash{$_} ) }
         ( 'rating', 'distribution', 'versions' );
 
     $c->stash( \%stash );

--- a/t/elasticsearch_adapter.t
+++ b/t/elasticsearch_adapter.t
@@ -3,16 +3,9 @@ use warnings;
 
 use Test::More;
 
-{
+use MetaCPAN::Web::Elasticsearch::Adapter
+    qw( single_valued_arrayref_to_scalar );
 
-    package    ## no critic (Package)
-        ExtractSingleElement;
-    use Moo;
-    with('MetaCPAN::Web::Role::Elasticsearch::Adapter');
-    1;
-}
-
-my $extractor = ExtractSingleElement->new;
 my $test_data = [
     {
         'name'     => 'MetaCPAN-Client',
@@ -34,6 +27,7 @@ my $test_data = [
     }
 
 ];
+
 my $expected_extraction = [
     {
         'name'     => 'MetaCPAN-Client',
@@ -55,9 +49,9 @@ my $expected_extraction = [
     }
 
 ];
-is_deeply $extractor->single_valued_arrayref_to_scalar(
-    $test_data, [ 'name', 'abstract' ]
-    ),
+
+is_deeply single_valued_arrayref_to_scalar( $test_data,
+    [ 'name', 'abstract' ] ),
     $expected_extraction,
     'flatten single element arrays when specified';
 


### PR DESCRIPTION
There is no real need for this to be in a Role, the functionality
does not depend on the object at all and it also makes it hard
to reuse by tests code.

This change moves it into an importable function we can use
where needed.
There are few coming test fixes that depend on it.