### PR TITLE
exclude t and xt directory from other files at search time

### DIFF
--- a/lib/MetaCPAN/Web/Model/API/Release.pm
+++ b/lib/MetaCPAN/Web/Model/API/Release.pm
@@ -295,6 +295,8 @@ sub interesting_files {
                             { term => { release   => $release } },
                             { term => { author    => $author } },
                             { term => { directory => \0 } },
+                            { not  => { prefix    => { 'path' => 'xt/' } } },
+                            { not  => { prefix    => { 'path' => 't/' } } },
                             {
                                 or => [
                                     {


### PR DESCRIPTION
We filter out any files in t or xt when separating out where to list
them on the release page.  If these files aren't filtered out in our
intial query, it can inflate the number of results over our 250 limit,
so that files we actually want to display won't be included.

This was the case for https://metacpan.org/release/OCBNET/CSS-Sass-3.3.4.
It has thousands of files in t/ named expected_output.css.  As a result,
most of the files we care about in the root weren't shown.