### PR TITLE
Fix/autocomplete label

### DIFF
--- a/root/static/css/jquery.autocomplete.css
+++ b/root/static/css/jquery.autocomplete.css
@@ -45,3 +45,12 @@ div.autocomplete-suggestions div:nth-child(2n+2) {
 .autocomplete-suggestion.autocomplete-selected {
   background: #BAD3EA !important; 
 }
+
+/*
+    When auto-completing author results in the search,
+    show them under "Authors"
+    GH #1707, Dan McCormick
+*/
+#autocomplete-direct-results:before {
+  content: 'Authors'
+}


### PR DESCRIPTION
Per GH #1707, when searching for authors, the auto-complete shows the found results under a label "Products". This adds a CSS rule to fix it and show them under a label "Authors".