### PR TITLE
Link to reverse deps for module on module page

### DIFF
--- a/root/inc/dependencies.html
+++ b/root/inc/dependencies.html
@@ -2,7 +2,7 @@
     <li class="nav-header">Dependencies</li>
 <%-
 deps = [];
-FOREACH dep IN dependencies;
+FOREACH dep IN release.dependency;
 IF dep.phase != 'runtime' || dep.relationship != 'requires' || dep.module == 'perl'; NEXT; END;
 deps.push(dep.module);
 END;
@@ -22,7 +22,11 @@ FOREACH dep IN deps.sort %>
         <i class="fa fa-retweet fa-fw black"></i>CPAN Testers List</a>
     </li>
     <li>
+      <%- IF module -%>
+        <a href="/requires/module/<% module.documentation or module.module.0.name %>?sort=[[2,1]]">
+      <%- ELSE -%>
         <a href="/requires/distribution/<% release.distribution %>?sort=[[2,1]]">
+      <%- END -%>
         <i class="fa fa-share fa-fw black"></i>Reverse dependencies</a>
     </li>
     <%- IF deps.size %>

--- a/root/pod.html
+++ b/root/pod.html
@@ -43,7 +43,7 @@
   <% INCLUDE inc/author-pic.html author = author %>
   <% INCLUDE inc/contributors.html contributors = contributors %>
   </div>
-  <% INCLUDE inc/dependencies.html dependencies = release.dependency %>
+  <% INCLUDE inc/dependencies.html release = release, module = module %>
   </div>
   <a name="___pod"></a>
   <div class="pod content anchors">

--- a/root/release.html
+++ b/root/release.html
@@ -30,7 +30,7 @@
 <% INCLUDE inc/author-pic.html author = author %>
 <% INCLUDE inc/contributors.html contributors = contributors %>
 </div>
-<% INCLUDE inc/dependencies.html dependencies = release.dependency %>
+<% INCLUDE inc/dependencies.html release = release %>
 </div>
 
 <div class="content">

--- a/t/controller/shared/release-info.t
+++ b/t/controller/shared/release-info.t
@@ -222,10 +222,11 @@ test_psgi app, sub {
             # TODO: search
             # TODO: toggle table of contents (module only)
 
+            my $revdep = $type eq 'module' ? 'module' : 'distribution';
             ok(
                 $tx->find_value(
-                    '//a[starts-with(@href, "/requires/distribution/")]'),
-                'reverse deps link uses dist name'
+                    "//a[starts-with(\@href, \"/requires/$revdep/$name?\")]"),
+                "reverse deps link uses $revdep name"
             );
 
             my $slash = '%2F';


### PR DESCRIPTION
There already is a /requires/module/<module> endpoint, so use that on
individual module pages instead of /requires/release/<dist>.

In passing, clean up the variable passing to inc/dependencies.html by
passing the release object, since it uses several fields from it, not
just the dependencies.