### PR TITLE
Remove erroneous trailing slashes from links

### DIFF
--- a/root/browse.html
+++ b/root/browse.html
@@ -11,8 +11,8 @@
     <% INCLUDE mobile/toolbar-search-form.html %>
   </li>
   <li class="nav-header">Tools</li>
-  <li><a data-keyboard-shortcut="g d" href="/release/<% author %>/<% release %>/"><i class="fa fa-fw fa-info-circle black"></i>Release Info</a></li>
-  <li><a data-keyboard-shortcut="g a" href="/author/<% author %>/"><i class="fa fa-user fa-fw black"></i>Author</a></li>
+  <li><a data-keyboard-shortcut="g d" href="/release/<% author %>/<% release %>"><i class="fa fa-fw fa-info-circle black"></i>Release Info</a></li>
+  <li><a data-keyboard-shortcut="g a" href="/author/<% author %>"><i class="fa fa-user fa-fw black"></i>Author</a></li>
   <li><a href="<% api_external_secure %>/source/<% base %>"><i class="fa fa-file-text-o fa-fw black"></i>Raw browser</a></li>
   <li class="nav-header">Info</li>
   <li><% count = files.grep(->{this.directory == 'true'}).size; count %> folder<% count != 1 ? "s" : "" %></li>

--- a/root/release.html
+++ b/root/release.html
@@ -10,7 +10,7 @@
     <% INCLUDE mobile/toolbar-search-form.html %>
     </li>
     <li class="nav-header"><span class="relatize"><% release.date.dt_http %></span></li>
-    <li><a href="/source/<% release.author %>/<% release.name %>/"><i class="fa fa-fw fa-folder-open black"></i>Browse</a> (<a href="<% api_external_secure %>/source/<% release.author %>/<% release.name %>/">raw</a>)</li>
+    <li><a href="/source/<% release.author %>/<% release.name %>"><i class="fa fa-fw fa-folder-open black"></i>Browse</a> (<a href="<% api_external_secure %>/source/<% release.author %>/<% release.name %>/">raw</a>)</li>
     <% PROCESS inc/release-info.html %>
     <li class="nav-header">Activity</li>
     <li><% INCLUDE inc/activity.html query = 'distribution=' _ release.distribution %></li>

--- a/root/source.html
+++ b/root/source.html
@@ -15,7 +15,7 @@
   </li>
   <li class="nav-header">Tools</li>
   <li>
-    <a data-keyboard-shortcut="g d" href="/release/<% module.author %>/<% module.release %>/"><i class="fa fa-info-circle fa-fw black"></i>Release Info</a>
+    <a data-keyboard-shortcut="g d" href="/release/<% module.author %>/<% module.release %>"><i class="fa fa-info-circle fa-fw black"></i>Release Info</a>
   </li>
   <% IF module.documentation %>
   <li>


### PR DESCRIPTION
The canonical URLs for release and author info and source browsing don't
have trailing slashes, so avoid an unnecessary redirect roundtrip by
removing them from navigation links.