### PR TITLE
Improved links and better distinction non-latest pages

### DIFF
--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -35,7 +35,7 @@ sub release : Local : Args {
         $c->detach();
     }
 
-    $c->stash->{pod_file} = $c->model('API::Module')->get(@path)->recv;
+    $c->stash->{pod_file}   = $c->model('API::Module')->get(@path)->recv;
     $c->stash->{permalinks} = 1;
     $c->forward( 'view', [@path] );
 }
@@ -66,7 +66,7 @@ sub distribution : Local : Args {
 sub view : Private {
     my ( $self, $c, @path ) = @_;
 
-    my $data = $c->stash->{pod_file};
+    my $data       = $c->stash->{pod_file};
     my $permalinks = $c->stash->{permalinks};
 
     if ( $data->{directory} ) {
@@ -91,8 +91,14 @@ sub view : Private {
     my $reqs = $self->api_requests(
         $c,
         {
-            pod => $c->model('API')
-                ->request( $pod_path, undef, { show_errors => 1, ($permalinks ? (permalinks => 1) : ()) } ),
+            pod => $c->model('API')->request(
+                $pod_path,
+                undef,
+                {
+                    show_errors => 1,
+                    ( $permalinks ? ( permalinks => 1 ) : () )
+                }
+            ),
             release => $c->model('API::Release')
                 ->get( @{$data}{qw(author release)} ),
         },

--- a/lib/MetaCPAN/Web/Controller/Pod.pm
+++ b/lib/MetaCPAN/Web/Controller/Pod.pm
@@ -36,6 +36,7 @@ sub release : Local : Args {
     }
 
     $c->stash->{pod_file} = $c->model('API::Module')->get(@path)->recv;
+    $c->stash->{permalinks} = 1;
     $c->forward( 'view', [@path] );
 }
 
@@ -66,6 +67,7 @@ sub view : Private {
     my ( $self, $c, @path ) = @_;
 
     my $data = $c->stash->{pod_file};
+    my $permalinks = $c->stash->{permalinks};
 
     if ( $data->{directory} ) {
         $c->res->redirect( '/source/' . join( q{/}, @path ), 301 );
@@ -90,7 +92,7 @@ sub view : Private {
         $c,
         {
             pod => $c->model('API')
-                ->request( $pod_path, undef, { show_errors => 1 } ),
+                ->request( $pod_path, undef, { show_errors => 1, ($permalinks ? (permalinks => 1) : ()) } ),
             release => $c->model('API::Release')
                 ->get( @{$data}{qw(author release)} ),
         },

--- a/lib/MetaCPAN/Web/Controller/Release.pm
+++ b/lib/MetaCPAN/Web/Controller/Release.pm
@@ -55,6 +55,7 @@ sub by_author_and_release : Chained('root') PathPart('') Args(2) {
         $c->detach();
     }
 
+    $c->stash->{permalinks} = 1;
     $c->stash->{data} = $model->get( $author, $release );
     $c->forward('view');
 }

--- a/root/inc/breadcrumbs.html
+++ b/root/inc/breadcrumbs.html
@@ -37,13 +37,13 @@ END %>
     <span class="dropdown"><b class="caret"></b></span>
     <select class="<% module ? "" : "extend" %>" onchange="document.location.href=this.value"><% PROCESS version_dropdown %></select>
     <% IF module %>
-    <a data-keyboard-shortcut="g d" class="release-name" href="/release/<% IF release.status == 'latest'; release.distribution; ELSE; [module.author, module.release].join('/'); END %>"><% release.name %></a>
+    <a data-keyboard-shortcut="g d" class="release-name" href="/release/<% IF permalinks; [module.author, module.release].join('/'); ELSE; release.distribution; END %>"><% release.name %></a>
     <% ELSE %>
       <span class="release-name"><% release.name %></span>
     <% END %>
     <% IF mark_unauthorized_releases && NOT release.authorized %><em class="warning">UNAUTHORIZED RELEASE</em><% END %>
   </div>
-  <%- IF release.status != 'latest';
+  <%- IF permalinks;
       FOREACH v IN versions; IF v.status == 'latest'; have_released = 1; END; END;
       IF have_released; %>
     <a class="latest" href="<% IF module %>/pod/<% module.documentation %><% ELSE %>/release/<% release.distribution; END %>" title="<%- IF release.maturity == 'developer'; 'dev release, '; END %>go to latest"><span class="fa fa-step-forward"></span></a>

--- a/root/inc/release-info.html
+++ b/root/inc/release-info.html
@@ -1,5 +1,5 @@
 <li>
-    <a data-keyboard-shortcut="g c" href="/changes/<% IF release.status == 'latest'; 'distribution/'; release.distribution; ELSE; ['release', release.author, release.name].join('/'); END %>"><i class="fa fa-fw fa-cogs black"></i>Changes</a>
+    <a data-keyboard-shortcut="g c" href="/changes/<% IF permalinks; ['release', release.author, release.name].join('/'); ELSE; ['distribution', release.distribution].join('/'); END %>"><i class="fa fa-fw fa-cogs black"></i>Changes</a>
 </li>
 <% IF is_url(release.resources.homepage) %>
 <li>

--- a/root/preprocess.html
+++ b/root/preprocess.html
@@ -62,7 +62,7 @@ profiles = {
     title = file.documentation || file.path;
     # If there is pod for this file...
     IF file.documentation || file.pod_lines.size || file.module.grep(->(module){ module.associated_pod }).size;
-      IF file.status == "latest";
+      IF !permalinks;
         # If it's a PAUSE-indexed module (02packages)...
         IF file.documentation
         && file.authorized


### PR DESCRIPTION
When picking release specific vs dist or module links, we should choose based on the URL of the current page rather than the status of the dist.  Even if we are on the latest release of a dist, the links should still be relative to the release if we are on a release specific URL.

For links we generate, control that in the templates.  For links in POD, pass the permalinks parameter as appropriate.

Related to cpan-api/cpan-api#497